### PR TITLE
Remove issues & projects section from Documentation Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,12 +1139,6 @@ Execute the commands below to build from the source after installing Ballerina S
     ballerina build --skip-tests
 ```
 
-## Issues and Projects 
-
-Issues and Projects tabs are disabled for this repository as this is part of the Ballerina Standard Library. To report bugs, request new features, start new discussions, view project boards, etc. please visit Ballerina Standard Library [parent repository](https://github.com/ballerina-platform/ballerina-standard-library). 
-
-This repository only contains the source code for the module.
-
 ## Contributing to Ballerina
 
 As an open source project, Ballerina welcomes contributions from the community. 


### PR DESCRIPTION
## Purpose
> Remove 'issues & projects' section from the connector Documentation Template, since it refers to stdlib.

## Goals
> Remove 'issues & projects' section from Documentation Template

## Approach
> 'issues & projects' section was removed from README.md 

## Documentation
> https://docs.google.com/document/d/19RTQqTfPyeXd-RHmcgdWJbZtFuu7O6y79oPtuGzYmiM/edit?usp=sharing

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
> Ballerina SLP8
> Ubuntu 20.04 OS
 