### PR TITLE
Migrate to Swan Lake Alpha 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ modules
 ballerina.conf
 
 resources
+
+Config.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 script:
-  - wget http://dist-dev.ballerina.io/downloads/swan-lake-preview8/ballerina-linux-installer-x64-swan-lake-preview8.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-preview8.deb
+  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha2/ballerina-linux-installer-x64-swan-lake-alpha2.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha2.deb
   - sudo apt-get install -f
-  - ballerina --version
-  - ballerina build --skip-tests
+  - bal --version
+  - bal build --skip-tests
   

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "azure_eventhub"
-version = "0.1.0"
+version = "0.1.1"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Azure","Eventhub"]

--- a/Module.md
+++ b/Module.md
@@ -28,7 +28,7 @@ The REST APIs fall into the following categories:
 # Compatibility
 |                     |    Version          |
 |:-------------------:|:-------------------:|
-| Ballerina Language  | swan-lake-preview8  |
+| Ballerina Language  | Swan-Lake-Alpha2    |
 
 # Supported Operations
 
@@ -88,12 +88,16 @@ First, import the ballerinax/azure_eventhub module into the Ballerina project.
 You can now make the connection configuration using the shared access key name, shared access key, and the resource 
 URI to the event hub namespace.
 ```ballerina
+    configurable string sasKeyName = ?;
+    configurable string sasKey = ?;
+    configurable string resourceUri = ?;
+
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI")
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 ```
 Note:
 You must specify the SAS key name, SAS key and the resource URI when configuring the Azure Event Hub Client connector.
@@ -137,12 +141,16 @@ First, import the ballerinax/azure_eventhub module into the Ballerina project.
 You can now make the connection configuration using the shared access key name, shared access key, and the resource URI 
 to the event hub namespace.
 ```ballerina
+    configurable string sasKeyName = ?;
+    configurable string sasKey = ?;
+    configurable string resourceUri = ?;
+
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI")
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 ```
 Note:
 You must specify the SAS key name, SAS key and the resource URI when configuring the Azure Event Hub Client connector.
@@ -156,8 +164,7 @@ named “mytesthub”.
         log:printError(createResult.message());
     }
     if (createResult is xml) {
-        
-    log:print(createResult.toString());
+        log:print(createResult.toString());
         log:print("Successfully Created Event Hub!");
     }
 
@@ -176,8 +183,7 @@ Here we are getting all the metadata associated with the event hub named “myte
         log:printError(getEventHubResult.message());
     }
     if (getEventHubResult is xml) {
-        
-    log:print(getEventHubResult.toString());
+        log:print(getEventHubResult.toString());
         log:print("Successfully Get Event Hub!");
     }
 ```
@@ -197,8 +203,7 @@ hub named “mytesthub”.
     if (updateResult is error) {
         log:printError(updateResult.message());
     }
-    if (updateResult is xml) {
-        
+    if (updateResult is xml) {       
         log:print(updateResult.toString());
         log:print("Successfully Updated Event Hub!");
     }
@@ -217,8 +222,7 @@ in the namespace. Here we are getting all the metadata associated with the event
         log:printError(listResult.message());
     }
     if (listResult is xml) {
-        
-    log:print(listResult.toString());
+        log:print(listResult.toString());
         log:print("Successfully Listed Event Hubs!");
     }
 ```
@@ -231,8 +235,7 @@ an event hub named “mytesthub”.
 ```ballerina
     var deleteResult = managementClient->deleteEventHub("mytesthub");
     if (deleteResult is error) {
-        
-    log:printError(msg = deleteResult.message());
+        log:printError(msg = deleteResult.message());
     } else {
         log:print("Successfully Deleted Event Hub!");
     }
@@ -254,7 +257,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->send("myhub", "eventData");
 }
 ```
@@ -272,7 +275,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -292,7 +295,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834";
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -312,7 +315,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -332,7 +335,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -359,7 +362,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -386,7 +389,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -413,7 +416,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -440,7 +443,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->createEventHub("myhub");
 }
 ```
@@ -457,7 +460,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->getEventHub("myhub");
 }
 ```
@@ -475,7 +478,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->deleteEventHub("myhub");
 }
 ```
@@ -492,7 +495,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->createConsumerGroup("myhub", "groupName");
 }
 ```
@@ -509,7 +512,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->getConsumerGroup("myhub", "groupName");
 }
 ```
@@ -527,7 +530,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->deleteConsumerGroup("myhub", "groupName");
 }
 ```

--- a/Package.md
+++ b/Package.md
@@ -28,7 +28,7 @@ The REST APIs fall into the following categories:
 # Compatibility
 |                     |    Version          |
 |:-------------------:|:-------------------:|
-| Ballerina Language  | swan-lake-preview8  |
+| Ballerina Language  | Swan-Lake-Alpha2    |
 
 # Supported Operations
 
@@ -88,12 +88,16 @@ First, import the ballerinax/azure_eventhub module into the Ballerina project.
 You can now make the connection configuration using the shared access key name, shared access key, and the resource 
 URI to the event hub namespace.
 ```ballerina
+    configurable string sasKeyName = ?;
+    configurable string sasKey = ?;
+    configurable string resourceUri = ?;
+
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI")
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 ```
 Note:
 You must specify the SAS key name, SAS key and the resource URI when configuring the Azure Event Hub Client connector.
@@ -137,12 +141,16 @@ First, import the ballerinax/azure_eventhub module into the Ballerina project.
 You can now make the connection configuration using the shared access key name, shared access key, and the resource URI 
 to the event hub namespace.
 ```ballerina
+    configurable string sasKeyName = ?;
+    configurable string sasKey = ?;
+    configurable string resourceUri = ?;
+
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI")
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 ```
 Note:
 You must specify the SAS key name, SAS key and the resource URI when configuring the Azure Event Hub Client connector.
@@ -156,8 +164,7 @@ named “mytesthub”.
         log:printError(createResult.message());
     }
     if (createResult is xml) {
-        
-    log:print(createResult.toString());
+        log:print(createResult.toString());
         log:print("Successfully Created Event Hub!");
     }
 
@@ -176,8 +183,7 @@ Here we are getting all the metadata associated with the event hub named “myte
         log:printError(getEventHubResult.message());
     }
     if (getEventHubResult is xml) {
-        
-    log:print(getEventHubResult.toString());
+        log:print(getEventHubResult.toString());
         log:print("Successfully Get Event Hub!");
     }
 ```
@@ -197,8 +203,7 @@ hub named “mytesthub”.
     if (updateResult is error) {
         log:printError(updateResult.message());
     }
-    if (updateResult is xml) {
-        
+    if (updateResult is xml) {       
         log:print(updateResult.toString());
         log:print("Successfully Updated Event Hub!");
     }
@@ -217,8 +222,7 @@ in the namespace. Here we are getting all the metadata associated with the event
         log:printError(listResult.message());
     }
     if (listResult is xml) {
-        
-    log:print(listResult.toString());
+        log:print(listResult.toString());
         log:print("Successfully Listed Event Hubs!");
     }
 ```
@@ -231,8 +235,7 @@ an event hub named “mytesthub”.
 ```ballerina
     var deleteResult = managementClient->deleteEventHub("mytesthub");
     if (deleteResult is error) {
-        
-    log:printError(msg = deleteResult.message());
+        log:printError(msg = deleteResult.message());
     } else {
         log:print("Successfully Deleted Event Hub!");
     }
@@ -254,7 +257,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->send("myhub", "eventData");
 }
 ```
@@ -272,7 +275,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -292,7 +295,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834";
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -312,7 +315,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -332,7 +335,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -359,7 +362,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -386,7 +389,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -413,7 +416,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:PublisherClient eventHubClient = new (config);
+   eventhub:PublisherClient eventHubClient = checkpanic new (config);
    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
    map<string> userProps = {Alert: "windy", warning: "true"};
 
@@ -440,7 +443,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->createEventHub("myhub");
 }
 ```
@@ -457,7 +460,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->getEventHub("myhub");
 }
 ```
@@ -475,7 +478,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->deleteEventHub("myhub");
 }
 ```
@@ -492,7 +495,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->createConsumerGroup("myhub", "groupName");
 }
 ```
@@ -509,7 +512,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->getConsumerGroup("myhub", "groupName");
 }
 ```
@@ -527,7 +530,7 @@ public function main() {
        sasKey: "<sas_key>",
        resourceUri: "<resource_uri>"
    };
-   eventhub:ManagementClient eventHubClient = new (config);
+   eventhub:ManagementClient eventHubClient = checkpanic new (config);
    var result = eventHubClient->deleteConsumerGroup("myhub", "groupName");
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1139,12 +1139,6 @@ Execute the commands below to build from the source after installing Ballerina S
     ballerina build --skip-tests
 ```
 
-## Issues and Projects 
-
-Issues and Projects tabs are disabled for this repository as this is part of the Ballerina Standard Library. To report bugs, request new features, start new discussions, view project boards, etc. please visit Ballerina Standard Library [parent repository](https://github.com/ballerina-platform/ballerina-standard-library). 
-
-This repository only contains the source code for the module.
-
 ## Contributing to Ballerina
 
 As an open source project, Ballerina welcomes contributions from the community. 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The REST APIs fall into the following categories:
 * Java 11 Installed
 Java Development Kit (JDK) with version 11 is required.
 
-* Ballerina SLP8 Installed
-Ballerina Swan Lake Preview Version 8 is required. 
+* Ballerina SLAlpha2 Installed
+Ballerina Swan Lake Alpha 2 is required. 
 
 * Connection String of the Event Hub Namespace
 We need management credentials to communicate with the Event Hubs. These credentials are available in the connection 
@@ -93,7 +93,7 @@ from the connection string.
 |                                   | Version               |
 |:---------------------------------:|:---------------------:|
 | Azure Event Hubs REST API Version | 2014-12               |
-| Ballerina Language                | Swan-Lake-Preview8    |
+| Ballerina Language                | Swan-Lake-Alpha2      |
 | Java Development Kit (JDK)        | 11                    |
 
 ## Limitations
@@ -136,12 +136,16 @@ First, import the ballerinax/azure_eventhub module into the Ballerina project.
 You can now make the connection configuration using the shared access key name, shared access key, and the resource 
 URI to the event hub namespace.
 ```ballerina
+    configurable string sasKeyName = ?;
+    configurable string sasKey = ?;
+    configurable string resourceUri = ?;
+
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI")
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 ```
 Note:
 You must specify the SAS key name, SAS key and the resource URI when configuring the Azure Event Hub Client connector.
@@ -203,12 +207,16 @@ First, import the ballerinax/azure_eventhub module into the Ballerina project.
 You can now make the connection configuration using the shared access key name, shared access key, and the resource URI 
 to the event hub namespace.
 ```ballerina
+    configurable string sasKeyName = ?;
+    configurable string sasKey = ?;
+    configurable string resourceUri = ?;
+
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI")
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 ```
 Note:
 You must specify the SAS key name, SAS key and the resource URI when configuring the Azure Event Hub Client connector.
@@ -222,8 +230,7 @@ named “mytesthub”.
         log:printError(createResult.message());
     }
     if (createResult is xml) {
-        
-    log:print(createResult.toString());
+        log:print(createResult.toString());
         log:print("Successfully Created Event Hub!");
     }
 
@@ -242,8 +249,7 @@ Here we are getting all the metadata associated with the event hub named “myte
         log:printError(getEventHubResult.message());
     }
     if (getEventHubResult is xml) {
-        
-    log:print(getEventHubResult.toString());
+        log:print(getEventHubResult.toString());
         log:print("Successfully Get Event Hub!");
     }
 ```
@@ -263,8 +269,7 @@ hub named “mytesthub”.
     if (updateResult is error) {
         log:printError(updateResult.message());
     }
-    if (updateResult is xml) {
-        
+    if (updateResult is xml) {       
         log:print(updateResult.toString());
         log:print("Successfully Updated Event Hub!");
     }
@@ -283,8 +288,7 @@ in the namespace. Here we are getting all the metadata associated with the event
         log:printError(listResult.message());
     }
     if (listResult is xml) {
-        
-    log:print(listResult.toString());
+        log:print(listResult.toString());
         log:print("Successfully Listed Event Hubs!");
     }
 ```
@@ -297,8 +301,7 @@ an event hub named “mytesthub”.
 ```ballerina
     var deleteResult = managementClient->deleteEventHub("mytesthub");
     if (deleteResult is error) {
-        
-    log:printError(msg = deleteResult.message());
+        log:printError(msg = deleteResult.message());
     } else {
         log:print("Successfully Deleted Event Hub!");
     }
@@ -324,25 +327,26 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
-  
-   var result = publisherClient->send("myhub", "eventData");
-   if (result is error) {
-       
- log:printError(msg = result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+    
+    var result = publisherClient->send("myeventhub", "eventData");
+    if (result is error) {
+        log:printError(msg = result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -359,28 +363,29 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   var result = publisherClient->send("myhub", "eventData", userProps, brokerProps);
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    var result = publisherClient->send("myeventhub", "eventData", userProps, brokerProps);
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -400,29 +405,30 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   // partition key used as the parameter is prioritized over the partition key provided in the brokerProperties
-   var result = publisherClient->send("myhub", "eventData", userProps, brokerProps, partitionKey = "groupName");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    // partition key used as the parameter is prioritized over the partition key provided in the brokerProperties
+    var result = publisherClient->send("myeventhub", "data", userProps, brokerProps, partitionKey = "groupName");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -440,28 +446,29 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   var result = publisherClient->send("myhub", "eventData", userProps, brokerProps, partitionId = 1);
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    var result = publisherClient->send("myeventhub", "data", userProps, brokerProps, partitionId = 1);
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -481,35 +488,36 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   azure_eventhub:BatchEvent batchEvent = {
-       events: [
-           {data: "Message1"},
-           {data: "Message2", brokerProperties: brokerProps},
-           {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-       ]
-   };
-   var result = publisherClient->sendBatch("myhub", batchEvent, partitionKey = "groupName");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    azure_eventhub:BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch("myeventhub", batchEvent);
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -531,35 +539,36 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   azure_eventhub:BatchEvent batchEvent = {
-       events: [
-           {data: "Message1"},
-           {data: "Message2", brokerProperties: brokerProps},
-           {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-       ]
-   };
-   var result = publisherClient->sendBatch("myhub", batchEvent, partitionKey = "groupName");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    azure_eventhub:BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch("myeventhub", batchEvent, partitionKey = "groupName");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -583,35 +592,36 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   azure_eventhub:BatchEvent batchEvent = {
-       events: [
-           {data: "Message1"},
-           {data: "Message2", brokerProperties: brokerProps},
-           {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-       ]
-   };
-   var result = publisherClient->sendBatch("myhub", batchEvent, publisherId = "device-1");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    azure_eventhub:BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch("myeventhub", batchEvent, publisherId = "device-1");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -632,29 +642,29 @@ Sample is available at:
 https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/master/samples/create_event_hub.bal
 
 ```ballerina
- 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->createEventHub("myhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->createEventHub("myhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -669,27 +679,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->getEventHub("myhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->getEventHub("myhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -704,30 +715,31 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   azure_eventhub:EventHubDescriptionToUpdate eventHubDescriptionToUpdate = {
-       MessageRetentionInDays: 5
-   };
-   var result = managementClient->updateEventHub("myhub", eventHubDescriptionToUpdate);
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    azure_eventhub:EventHubDescriptionToUpdate eventHubDescriptionToUpdate = {
+        MessageRetentionInDays: 5
+    };
+    var result = managementClient->updateEventHub("myhub", eventHubDescriptionToUpdate);
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -742,27 +754,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->listEventHubs();
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("listReceived");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->listEventHubs();
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("listReceived");
+    }
 }
 ```
 
@@ -776,25 +789,26 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient= new (config);
- 
-   var result = managementClient->deleteEventHub("myhub");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient= checkpanic new (config);
+
+    var result = managementClient->deleteEventHub("myhub");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -809,27 +823,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->createConsumerGroup("myhub", "groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->createConsumerGroup("myeventhub", "consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -848,27 +863,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->getConsumerGroup("myhub", "groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->getConsumerGroup("myeventhub", "consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -887,27 +903,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->listConsumerGroups("myhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->listConsumerGroups("myeventhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -923,27 +940,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->listPartitions("myhub", "groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->listPartitions("myeventhub", "consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -959,27 +977,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->getPartition("myhub", "groupname", 1);
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->getPartition("myeventhub", "consumerGroup1", 1);
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -998,25 +1017,27 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->deleteConsumerGroup("myhub","groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is ()) {
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->deleteConsumerGroup("myeventhub","consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is ()) {
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -1035,28 +1056,29 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   var result = publisherClient->getRevokedPublishers("myeventhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       log:print("listReceived");
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    var result = publisherClient->getRevokedPublishers("myeventhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print("listReceived");
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -1068,16 +1090,29 @@ Sample is available at:
 https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/master/samples/revoke_publisher.bal
 
 ```ballerina
-import ballerinax/azure.eventhub as eventhub;
- 
+import ballerinax/azure_eventhub;
+import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-  eventhub:ClientEndpointConfiguration config = {
-      sasKeyName: "<sas_key_name>",
-      sasKey: "<sas_key>",
-      resourceUri: "<resource_uri>"
-  };
-  eventhub:Client c = <eventhub:Client>new eventhub:Client(config);
-  var b = c->revokePublisher("myeventhub", "device-1");
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    var result = publisherClient->revokePublisher("myeventhub", "device-1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -1090,25 +1125,27 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   var result = publisherClient->resumePublisher("myeventhub", "device-1");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is ()) {
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    var result = publisherClient->resumePublisher("myeventhub", "device-1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is ()) {
+        log:print("successful");
+    }
 }
 ```
 ## Building from the Source
@@ -1123,7 +1160,7 @@ public function main() {
 
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-2. Download and install [Ballerina SLP8](https://ballerina.io/). 
+2. Download and install [Ballerina Swann Lake Alpha2](https://ballerina.io/). 
 
 ### Building the Source
 

--- a/management_endpoint.bal
+++ b/management_endpoint.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 import ballerina/lang.'xml as xmllib;
-import ballerina/stringutils;
+import ballerina/regex;
 
 # Eventhub management client implementation.
 #
@@ -27,10 +27,10 @@ public client class ManagementClient {
     private string API_PREFIX = EMPTY_STRING;
     private http:Client clientEndpoint;
 
-    public function init(ClientEndpointConfiguration config) {
+    public function init(ClientEndpointConfiguration config) returns error? {
         self.config = config;
         self.API_PREFIX = TIME_OUT + config.timeout.toString() + API_VERSION + config.apiVersion;
-        self.clientEndpoint = new (HTTPS + self.config.resourceUri);
+        self.clientEndpoint = check new (HTTPS + self.config.resourceUri);
     }
 
     # Create a new Eventhub
@@ -100,7 +100,7 @@ public client class ManagementClient {
         http:Response response = <http:Response> check self.clientEndpoint->get(requestPath, req);
         if (response.statusCode == http:STATUS_OK) {
             string textPayload = check response.getTextPayload();
-            string cleanedStringXMLObject = stringutils:replaceAll(textPayload, XML_BASE, BASE);
+            string cleanedStringXMLObject = regex:replaceAll(textPayload, XML_BASE, BASE);
             xml xmlPayload = check 'xml:fromString(cleanedStringXMLObject);
             return xmlPayload;       
         } 
@@ -132,7 +132,7 @@ public client class ManagementClient {
         http:Response response = <http:Response> check self.clientEndpoint->get(requestPath, req);
         if (response.statusCode == http:STATUS_OK) {
             string textPayload = check response.getTextPayload();
-            string cleanedStringXMLObject = stringutils:replaceAll(textPayload, XML_BASE, BASE);
+            string cleanedStringXMLObject = regex:replaceAll(textPayload, XML_BASE, BASE);
             xml xmlPayload = check 'xml:fromString(cleanedStringXMLObject);
             return xmlPayload;
         } 
@@ -221,7 +221,7 @@ public client class ManagementClient {
         http:Response response = <http:Response> check self.clientEndpoint->get(requestPath, req);
         if (response.statusCode == http:STATUS_OK) {
             string textPayload = check response.getTextPayload();
-            string cleanedStringXMLObject = stringutils:replaceAll(textPayload, XML_BASE, BASE);
+            string cleanedStringXMLObject = regex:replaceAll(textPayload, XML_BASE, BASE);
             xml xmlPayload = check 'xml:fromString(cleanedStringXMLObject);
             return xmlPayload;
         } 

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,1 +1,2 @@
 ballerina.conf
+Config.toml

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,25 +15,26 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
-  
-   var result = publisherClient->send("myhub", "eventData");
-   if (result is error) {
-       
- log:printError(msg = result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+    
+    var result = publisherClient->send("myeventhub", "eventData");
+    if (result is error) {
+        log:printError(msg = result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -50,28 +51,29 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   var result = publisherClient->send("myhub", "eventData", userProps, brokerProps);
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    var result = publisherClient->send("myeventhub", "eventData", userProps, brokerProps);
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -91,29 +93,30 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   // partition key used as the parameter is prioritized over the partition key provided in the brokerProperties
-   var result = publisherClient->send("myhub", "eventData", userProps, brokerProps, partitionKey = "groupName");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    // partition key used as the parameter is prioritized over the partition key provided in the brokerProperties
+    var result = publisherClient->send("myeventhub", "data", userProps, brokerProps, partitionKey = "groupName");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -131,28 +134,29 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   var result = publisherClient->send("myhub", "eventData", userProps, brokerProps, partitionId = 1);
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    var result = publisherClient->send("myeventhub", "data", userProps, brokerProps, partitionId = 1);
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -172,35 +176,36 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   azure_eventhub:BatchEvent batchEvent = {
-       events: [
-           {data: "Message1"},
-           {data: "Message2", brokerProperties: brokerProps},
-           {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-       ]
-   };
-   var result = publisherClient->sendBatch("myhub", batchEvent, partitionKey = "groupName");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    azure_eventhub:BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch("myeventhub", batchEvent);
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -222,35 +227,36 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   azure_eventhub:BatchEvent batchEvent = {
-       events: [
-           {data: "Message1"},
-           {data: "Message2", brokerProperties: brokerProps},
-           {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-       ]
-   };
-   var result = publisherClient->sendBatch("myhub", batchEvent, partitionKey = "groupName");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    azure_eventhub:BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch("myeventhub", batchEvent, partitionKey = "groupName");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -274,35 +280,36 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
-   map<string> userProps = {Alert: "windy", warning: "true"};
- 
-   azure_eventhub:BatchEvent batchEvent = {
-       events: [
-           {data: "Message1"},
-           {data: "Message2", brokerProperties: brokerProps},
-           {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-       ]
-   };
-   var result = publisherClient->sendBatch("myhub", batchEvent, publisherId = "device-1");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    azure_eventhub:BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch("myeventhub", batchEvent, publisherId = "device-1");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 Note:
@@ -325,27 +332,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 ```ballerina
  
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->createEventHub("myhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->createEventHub("myhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -360,27 +368,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->getEventHub("myhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->getEventHub("myhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -395,30 +404,31 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   azure_eventhub:EventHubDescriptionToUpdate eventHubDescriptionToUpdate = {
-       MessageRetentionInDays: 5
-   };
-   var result = managementClient->updateEventHub("myhub", eventHubDescriptionToUpdate);
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    azure_eventhub:EventHubDescriptionToUpdate eventHubDescriptionToUpdate = {
+        MessageRetentionInDays: 5
+    };
+    var result = managementClient->updateEventHub("myhub", eventHubDescriptionToUpdate);
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -433,27 +443,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->listEventHubs();
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("listReceived");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->listEventHubs();
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("listReceived");
+    }
 }
 ```
 
@@ -467,25 +478,26 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient= new (config);
- 
-   var result = managementClient->deleteEventHub("myhub");
-   if (result is error) {
-       
- log:printError(result.message());
-   } else {
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient= checkpanic new (config);
+
+    var result = managementClient->deleteEventHub("myhub");
+    if (result is error) {
+        log:printError(result.message());
+    } else {
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -500,27 +512,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->createConsumerGroup("myhub", "groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->createConsumerGroup("myeventhub", "consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -539,27 +552,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->getConsumerGroup("myhub", "groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->getConsumerGroup("myeventhub", "consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -578,27 +592,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->listConsumerGroups("myhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->listConsumerGroups("myeventhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -614,27 +629,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->listPartitions("myhub", "groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->listPartitions("myeventhub", "consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -650,27 +666,28 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->getPartition("myhub", "groupname", 1);
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       
- log:print(result.toString());
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->getPartition("myeventhub", "consumerGroup1", 1);
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -689,25 +706,27 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:ManagementClient managementClient = new (config);
- 
-   var result = managementClient->deleteConsumerGroup("myhub","groupname");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is ()) {
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+
+    var result = managementClient->deleteConsumerGroup("myeventhub","consumerGroup1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is ()) {
+        log:print("successful");
+    }
 }
 ```
 Note:
@@ -726,28 +745,29 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   var result = publisherClient->getRevokedPublishers("myeventhub");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is xml) {
-       log:print("listReceived");
-       
- log:print(result.toString());
-       log:print("Successful!");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    var result = publisherClient->getRevokedPublishers("myeventhub");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print("listReceived");
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -759,16 +779,29 @@ Sample is available at:
 https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/master/samples/revoke_publisher.bal
 
 ```ballerina
-import ballerinax/azure.eventhub as eventhub;
- 
+import ballerinax/azure_eventhub;
+import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-  eventhub:ClientEndpointConfiguration config = {
-      sasKeyName: "<sas_key_name>",
-      sasKey: "<sas_key>",
-      resourceUri: "<resource_uri>"
-  };
-  eventhub:Client c = <eventhub:Client>new eventhub:Client(config);
-  var b = c->revokePublisher("myeventhub", "device-1");
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    var result = publisherClient->revokePublisher("myeventhub", "device-1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is xml) {
+        log:print(result.toString());
+        log:print("Successful!");
+    }
 }
 ```
 
@@ -781,24 +814,26 @@ https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/mast
 
 ```ballerina
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
- 
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 public function main() {
-   
-   azure_eventhub:ClientEndpointConfiguration config = {
-       sasKeyName: config:getAsString("SAS_KEY_NAME"),
-       sasKey: config:getAsString("SAS_KEY"),
-       resourceUri: config:getAsString("RESOURCE_URI")
-   };
-   azure_eventhub:PublisherClient publisherClient = new (config);
- 
-   var result = publisherClient->resumePublisher("myeventhub", "device-1");
-   if (result is error) {
-       log:printError(result.message());
-   }
-   if (result is ()) {
-       log:print("successful");
-   }
+    azure_eventhub:ClientEndpointConfiguration config = {
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
+    };
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
+
+    var result = publisherClient->resumePublisher("myeventhub", "device-1");
+    if (result is error) {
+        log:printError(result.message());
+    }
+    if (result is ()) {
+        log:print("successful");
+    }
 }
 ```

--- a/samples/create_consumer_group.bal
+++ b/samples/create_consumer_group.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->createConsumerGroup("myeventhub", "consumerGroup1");
     if (result is error) {

--- a/samples/create_event_hub.bal
+++ b/samples/create_event_hub.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->createEventHub("myhub");
     if (result is error) {

--- a/samples/create_event_hub_with_eventhub_description.bal
+++ b/samples/create_event_hub_with_eventhub_description.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     azure_eventhub:EventHubDescription eventHubDescription = {
         MessageRetentionInDays: 3,

--- a/samples/create_use_delete_eventhub.bal
+++ b/samples/create_use_delete_eventhub.bal
@@ -15,17 +15,20 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     // ------------------------------------ Event Hub Creation-----------------------------------------------
     azure_eventhub:EventHubDescription eventHubDescription = {

--- a/samples/delete_consumer_groups.bal
+++ b/samples/delete_consumer_groups.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->deleteConsumerGroup("myeventhub","consumerGroup1");
     if (result is error) {

--- a/samples/delete_event_hub.bal
+++ b/samples/delete_event_hub.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient= new (config);
+    azure_eventhub:ManagementClient managementClient= checkpanic new (config);
 
     var result = managementClient->deleteEventHub("myhub");
     if (result is error) {

--- a/samples/delete_event_hub_with_eventhub_description.bal
+++ b/samples/delete_event_hub_with_eventhub_description.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->deleteEventHub("myhubnew");
     if (result is error) {

--- a/samples/eventhub_management.bal
+++ b/samples/eventhub_management.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     // ------------------------------------ Event Hub Creation-----------------------------------------------
     var createResult = managementClient->createEventHub("mytesthub");

--- a/samples/get_consumer_group.bal
+++ b/samples/get_consumer_group.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->getConsumerGroup("myeventhub", "consumerGroup1");
     if (result is error) {

--- a/samples/get_event_hub.bal
+++ b/samples/get_event_hub.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->getEventHub("myhub");
     if (result is error) {

--- a/samples/get_partition.bal
+++ b/samples/get_partition.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->getPartition("myeventhub", "consumerGroup1", 1);
     if (result is error) {

--- a/samples/get_revoked_publishers.bal
+++ b/samples/get_revoked_publishers.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     var result = publisherClient->getRevokedPublishers("myeventhub");
     if (result is error) {

--- a/samples/list_consumer_groups.bal
+++ b/samples/list_consumer_groups.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->listConsumerGroups("myeventhub");
     if (result is error) {

--- a/samples/list_event_hubs.bal
+++ b/samples/list_event_hubs.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->listEventHubs();
     if (result is error) {

--- a/samples/list_partitions.bal
+++ b/samples/list_partitions.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     var result = managementClient->listPartitions("myeventhub", "consumerGroup1");
     if (result is error) {

--- a/samples/resume_publisher.bal
+++ b/samples/resume_publisher.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     var result = publisherClient->resumePublisher("myeventhub", "device-1");
     if (result is error) {

--- a/samples/revoke_publisher.bal
+++ b/samples/revoke_publisher.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     var result = publisherClient->revokePublisher("myeventhub", "device-1");
     if (result is error) {

--- a/samples/send_batch_event.bal
+++ b/samples/send_batch_event.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/send_batch_event_to_partition.bal
+++ b/samples/send_batch_event_to_partition.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/send_batch_event_with_partition_key.bal
+++ b/samples/send_batch_event_with_partition_key.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {PartitionKey: "groupName", CorrelationId: "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/send_batch_event_with_publisherId.bal
+++ b/samples/send_batch_event_with_publisherId.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/send_event.bal
+++ b/samples/send_event.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
     
     var result = publisherClient->send("myeventhub", "eventData");
     if (result is error) {

--- a/samples/send_event_with_broker_and_user_properties.bal
+++ b/samples/send_event_with_broker_and_user_properties.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {"CorrelationId": "32119834", "CorrelationId2": "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/send_event_with_partition_key.bal
+++ b/samples/send_event_with_partition_key.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {PartitionKey: "groupName1", CorrelationId: "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/send_partition_event.bal
+++ b/samples/send_partition_event.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:PublisherClient publisherClient = new (config);
+    azure_eventhub:PublisherClient publisherClient = checkpanic new (config);
 
     map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
     map<string> userProps = {Alert: "windy", warning: "true"};

--- a/samples/update_event_hub.bal
+++ b/samples/update_event_hub.bal
@@ -15,16 +15,19 @@
 // under the License.
 
 import ballerinax/azure_eventhub;
-import ballerina/config;
 import ballerina/log;
+
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
 
 public function main() {
     azure_eventhub:ClientEndpointConfiguration config = {
-        sasKeyName: config:getAsString("SAS_KEY_NAME"),
-        sasKey: config:getAsString("SAS_KEY"),
-        resourceUri: config:getAsString("RESOURCE_URI") 
+        sasKeyName: sasKeyName,
+        sasKey: sasKey,
+        resourceUri: resourceUri 
     };
-    azure_eventhub:ManagementClient managementClient = new (config);
+    azure_eventhub:ManagementClient managementClient = checkpanic new (config);
 
     azure_eventhub:EventHubDescriptionToUpdate eventHubDescriptionToUpdate = {
         MessageRetentionInDays: 5

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -169,28 +169,6 @@ function testSendBatchEventToPartition() {
 }
 
 @test:Config {
-    groups: ["publisher"],
-    enable: true
-}
-function testSendBatchEventWithPublisherID() {
-    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
-    map<string> userProps = {Alert: "windy", warning: "true"};
-
-    BatchEvent batchEvent = {
-        events: [
-            {data: "Message1"},
-            {data: "Message2", brokerProperties: brokerProps},
-            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-        ]
-    };
-    var result = publisherClient->sendBatch(event_hub_name1, batchEvent, publisherId = "device-1");
-    if (result is error) {
-        test:assertFail(msg = result.message());
-    }
-    test:assertTrue(result is ());
-}
-
-@test:Config {
     groups: ["eventHubManagment"],
     enable: true
 }
@@ -303,6 +281,28 @@ function testCreateEventHubWithEventHubDescription() {
 }
 function testDeleteEventHubWithEventHubDescription() {
     var result = managementClient->deleteEventHub(event_hub_name3);
+    if (result is error) {
+        test:assertFail(msg = result.message());
+    }
+    test:assertTrue(result is ());
+}
+
+@test:Config {
+    groups: ["publisher"],
+    enable: true
+}
+function testSendBatchEventWithPublisherID() {
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch(event_hub_name1, batchEvent, publisherId = "device-1");
     if (result is error) {
         test:assertFail(msg = result.message());
     }

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -15,17 +15,20 @@
 // under the License.
 
 import ballerina/test;
-import ballerina/config;
-import ballerina/system;
+import ballerina/os;
 import ballerina/log;
 
+configurable string sasKeyName = ?;
+configurable string sasKey = ?;
+configurable string resourceUri = ?;
+
 ClientEndpointConfiguration config = {
-    sasKeyName: getConfigValue("SAS_KEY_NAME"),
-    sasKey: getConfigValue("SAS_KEY"),
-    resourceUri: getConfigValue("RESOURCE_URI")
+    sasKeyName: (os:getEnv("SAS_KEY_NAME") != "") ? os:getEnv("SAS_KEY_NAME") : sasKeyName,
+    sasKey: (os:getEnv("SAS_KEY") != "") ? os:getEnv("SAS_KEY") : sasKey,
+    resourceUri: (os:getEnv("RESOURCE_URI") != "") ? os:getEnv("RESOURCE_URI") : resourceUri
 };
-ManagementClient managementClient = new (config);
-PublisherClient publisherClient = new (config);
+ManagementClient managementClient = checkpanic new (config);
+PublisherClient publisherClient = checkpanic new (config);
 
 var randomString = createRandomUUIDWithoutHyphens();
 
@@ -208,7 +211,7 @@ function testCreateEventHub() {
 
 @test:Config {
     groups: ["eventHubManagment"],
-    dependsOn: ["testCreateEventHub"],
+    dependsOn: [testCreateEventHub],
     enable: true
 }
 function testGetEventHub() {
@@ -224,7 +227,7 @@ function testGetEventHub() {
 
 @test:Config {
     groups: ["eventHubManagment"],
-    dependsOn: ["testCreateEventHub"],
+    dependsOn: [testCreateEventHub],
     enable: true
 }
 function testUpdateEventHub() {
@@ -244,7 +247,7 @@ function testUpdateEventHub() {
 //TODO: Fix xml returned cannot be converted to string
 @test:Config {
     groups: ["eventHubManagment"],
-    dependsOn: ["testCreateEventHub"],
+    dependsOn: [testCreateEventHub],
     enable: true
 }
 function testListEventHubs() {
@@ -262,10 +265,10 @@ function testListEventHubs() {
 @test:Config {
     groups: ["eventHubManagment"],
     dependsOn: [
-        "testCreateEventHub",
-        "testGetEventHub",
-        "testUpdateEventHub",
-        "testListEventHubs"
+        testCreateEventHub,
+        testGetEventHub,
+        testUpdateEventHub,
+        testListEventHubs
     ],
     enable: true
 }
@@ -279,7 +282,7 @@ function testDeleteEventHub() {
 
 @test:Config {
     groups: ["eventHubManagment"],
-    dependsOn: ["testDeleteEventHub"],
+    dependsOn: [testDeleteEventHub],
     enable: true
 }
 function testCreateEventHubWithEventHubDescription() {
@@ -299,7 +302,7 @@ function testCreateEventHubWithEventHubDescription() {
 
 @test:Config {
     groups: ["eventHubManagment"],
-    dependsOn: ["testCreateEventHubWithEventHubDescription"],
+    dependsOn: [testCreateEventHubWithEventHubDescription],
     enable: true
 }
 function testDeleteEventHubWithEventHubDescription() {
@@ -312,7 +315,7 @@ function testDeleteEventHubWithEventHubDescription() {
 
 @test:Config {
     groups: ["publisher"],
-    dependsOn: ["testSendBatchEventWithPublisherID"],
+    dependsOn: [testSendBatchEventWithPublisherID],
     enable: true
 }
 function testRevokePublisher() {
@@ -343,7 +346,7 @@ function testSendEventWithPublisherID() {
 //TODO: xml returned cannot be converted to string
 @test:Config {
     groups: ["publisher"],
-    dependsOn: ["testRevokePublisher"],
+    dependsOn: [testRevokePublisher],
     enable: true
 }
 function testGetRevokedPublishers() {
@@ -361,8 +364,8 @@ function testGetRevokedPublishers() {
 @test:Config {
     groups: ["publisher"],
     dependsOn: [
-        "testRevokePublisher",
-        "testGetRevokedPublishers"
+        testRevokePublisher,
+        testGetRevokedPublishers
     ],
     enable: true
 }
@@ -394,7 +397,7 @@ function testCreateConsumerGroup() {
 
 @test:Config {
     groups: ["consumergroup"],
-    dependsOn: ["testCreateConsumerGroup"],
+    dependsOn: [testCreateConsumerGroup],
     enable: true
 }
 function testGetConsumerGroup() {
@@ -410,7 +413,7 @@ function testGetConsumerGroup() {
 
 @test:Config {
     groups: ["consumergroup"],
-    dependsOn: ["testCreateConsumerGroup"],
+    dependsOn: [testCreateConsumerGroup],
     enable: true
 }
 function testListConsumerGroups() {
@@ -427,7 +430,7 @@ function testListConsumerGroups() {
 
 @test:Config {
     groups: ["consumergroup"],
-    dependsOn: ["testCreateConsumerGroup"],
+    dependsOn: [testCreateConsumerGroup],
     enable: true
 }
 function testListPartitions() {
@@ -444,7 +447,7 @@ function testListPartitions() {
 
 @test:Config {
     groups: ["consumergroup"],
-    dependsOn: ["testCreateConsumerGroup"],
+    dependsOn: [testCreateConsumerGroup],
     enable: true
 }
 function testGetPartition() {
@@ -461,11 +464,11 @@ function testGetPartition() {
 @test:Config {
     groups: ["consumergroup"],
     dependsOn: [
-        "testCreateConsumerGroup",
-        "testGetConsumerGroup",
-        "testListConsumerGroups",
-        "testListPartitions",
-        "testGetPartition"
+        testCreateConsumerGroup,
+        testGetConsumerGroup,
+        testListConsumerGroups,
+        testListPartitions,
+        testGetPartition
     ],
     enable: true
 }
@@ -490,9 +493,9 @@ function afterSuiteFunc() {
     test:assertTrue(result is ());
 }
 
-# Get configuration value for the given key from ballerina.conf file.
-# 
-# + return - configuration value of the given key as a string
-isolated function getConfigValue(string key) returns string {
-    return (system:getEnv(key) != "") ? system:getEnv(key) : config:getAsString(key);
-}
+// # Get configuration value for the given key from ballerina.conf file.
+// # 
+// # + return - configuration value of the given key as a string
+// isolated function getConfigValue(string key) returns string {
+//     return (os:getEnv(key) != "") ? os:getEnv(key) : config:getAsString(key);
+// }

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -18,14 +18,10 @@ import ballerina/test;
 import ballerina/os;
 import ballerina/log;
 
-configurable string sasKeyName = ?;
-configurable string sasKey = ?;
-configurable string resourceUri = ?;
-
 ClientEndpointConfiguration config = {
-    sasKeyName: (os:getEnv("SAS_KEY_NAME") != "") ? os:getEnv("SAS_KEY_NAME") : sasKeyName,
-    sasKey: (os:getEnv("SAS_KEY") != "") ? os:getEnv("SAS_KEY") : sasKey,
-    resourceUri: (os:getEnv("RESOURCE_URI") != "") ? os:getEnv("RESOURCE_URI") : resourceUri
+    sasKeyName: os:getEnv("SAS_KEY_NAME"),
+    sasKey: os:getEnv("SAS_KEY"),
+    resourceUri: os:getEnv("RESOURCE_URI")
 };
 ManagementClient managementClient = checkpanic new (config);
 PublisherClient publisherClient = checkpanic new (config);

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -169,6 +169,28 @@ function testSendBatchEventToPartition() {
 }
 
 @test:Config {
+    groups: ["publisher"],
+    enable: true
+}
+function testSendBatchEventWithPublisherID() {
+    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
+    map<string> userProps = {Alert: "windy", warning: "true"};
+
+    BatchEvent batchEvent = {
+        events: [
+            {data: "Message1"},
+            {data: "Message2", brokerProperties: brokerProps},
+            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
+        ]
+    };
+    var result = publisherClient->sendBatch(event_hub_name1, batchEvent, publisherId = "device-1");
+    if (result is error) {
+        test:assertFail(msg = result.message());
+    }
+    test:assertTrue(result is ());
+}
+
+@test:Config {
     groups: ["eventHubManagment"],
     enable: true
 }
@@ -289,29 +311,6 @@ function testDeleteEventHubWithEventHubDescription() {
 
 @test:Config {
     groups: ["publisher"],
-    enable: true
-}
-function testSendBatchEventWithPublisherID() {
-    map<string> brokerProps = {CorrelationId: "32119834", CorrelationId2: "32119834"};
-    map<string> userProps = {Alert: "windy", warning: "true"};
-
-    BatchEvent batchEvent = {
-        events: [
-            {data: "Message1"},
-            {data: "Message2", brokerProperties: brokerProps},
-            {data: "Message3", brokerProperties: brokerProps, userProperties: userProps}
-        ]
-    };
-    var result = publisherClient->sendBatch(event_hub_name1, batchEvent, publisherId = "device-1");
-    if (result is error) {
-        test:assertFail(msg = result.message());
-    }
-    test:assertTrue(result is ());
-}
-
-@test:Config {
-    groups: ["publisher"],
-    dependsOn: [testSendBatchEventWithPublisherID],
     enable: true
 }
 function testRevokePublisher() {


### PR DESCRIPTION
## Purpose
> The Azure Event Hubs Ballerina Connector was in SLP8. It is required to migrate the module, samples and documentation to Swan Lake Alpha 2.
Resolves https://github.com/wso2-enterprise/choreo/issues/2715

## Goals
> To migrate Azure Event Hubs Ballerina Connector in SLP8 to Swan Lake Alpha 2

## Approach
> The Azure Event Hubs Ballerina Connector modules, samples and documentation was migrated to Swan Lake Alpha 2.

## Release note
> 0.1.1

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Automated

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/pull/7

## Test environment
> JDK 11
> SLAlpha 2
> Ubuntu 20.04