### PR TITLE
Migrate to vSlAlpha5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha4/ballerina-linux-installer-x64-swan-lake-alpha4.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha4.deb
+  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha5/ballerina-linux-installer-x64-swan-lake-alpha5.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha5.deb
   - sudo apt-get install -f
   - bal --version
   - bal build --skip-tests

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "azure_eventhub"
-version = "0.1.2"
+version = "0.1.3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Azure","Eventhub"]

--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -1,12 +1,12 @@
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "regex"
-version = "0.7.0-alpha7"
+version = "0.7.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
@@ -16,41 +16,41 @@ version = "0.0.0"
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-alpha8"
+version = "2.0.0-alpha9"
 
 [[dependency]]
 org = "ballerina"
 name = "xmldata"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-alpha7"
+version = "0.8.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "0.6.0-alpha7"
+version = "0.6.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "mime"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 

--- a/Module.md
+++ b/Module.md
@@ -28,7 +28,7 @@ The REST APIs fall into the following categories:
 # Compatibility
 |                     |    Version          |
 |:-------------------:|:-------------------:|
-| Ballerina Language  | Swan-Lake-Alpha4    |
+| Ballerina Language  | Swan-Lake-Alpha5    |
 
 # Supported Operations
 

--- a/Package.md
+++ b/Package.md
@@ -28,7 +28,7 @@ The REST APIs fall into the following categories:
 # Compatibility
 |                     |    Version          |
 |:-------------------:|:-------------------:|
-| Ballerina Language  | Swan-Lake-Alpha4    |
+| Ballerina Language  | Swan-Lake-Alpha5    |
 
 # Supported Operations
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The REST APIs fall into the following categories:
 * Java 11 Installed
 Java Development Kit (JDK) with version 11 is required.
 
-* Ballerina SLAlpha4 Installed
-Ballerina Swan Lake Alpha 4 is required. 
+* Ballerina SLAlpha5 Installed
+Ballerina Swan Lake Alpha 5 is required. 
 
 * Connection String of the Event Hub Namespace
 We need management credentials to communicate with the Event Hubs. These credentials are available in the connection 
@@ -93,7 +93,7 @@ from the connection string.
 |                                   | Version               |
 |:---------------------------------:|:---------------------:|
 | Azure Event Hubs REST API Version | 2014-12               |
-| Ballerina Language                | Swan-Lake-Alpha4      |
+| Ballerina Language                | Swan-Lake-Alpha5      |
 | Java Development Kit (JDK)        | 11                    |
 
 ## Limitations


### PR DESCRIPTION
## Purpose
> Migrate the connector to Swan Lake Alpha 5.
Resolves https://github.com/wso2-enterprise/choreo/issues/3761

## Goals
> Migrate Github connector to Swan Lake Alpha 5.