### PR TITLE
[SL Alpha 5] Remove union type for event data

### DIFF
--- a/data_mappings.bal
+++ b/data_mappings.bal
@@ -25,16 +25,15 @@ import ballerina/xmldata;
 isolated function getBatchEventJson(BatchEvent batchEvent) returns json {
     json[] message = [];
     foreach var item in batchEvent.events {
-        json data = checkpanic item.data.cloneWithType(json);
         json jsonMessage = {
-            Body: data
+            Body: item.data
         };
         if (!(item["userProperties"] is ())) {
-            json userProperties = {UserProperties:checkpanic item["userProperties"].cloneWithType(json)};
+            json userProperties = {UserProperties: checkpanic item["userProperties"].cloneWithType(json)};
             jsonMessage = checkpanic jsonMessage.mergeJson(userProperties);
         }
         if (!(item["brokerProperties"] is ())) {
-            json brokerProperties = {BrokerProperties:checkpanic item["brokerProperties"].cloneWithType(json)};
+            json brokerProperties = {BrokerProperties: checkpanic item["brokerProperties"].cloneWithType(json)};
             jsonMessage = checkpanic jsonMessage.mergeJson(brokerProperties);
         }
         message.push(jsonMessage);

--- a/types.bal
+++ b/types.bal
@@ -43,7 +43,7 @@ public type ClientEndpointConfiguration record {|
 @display {label: "Event"}
 public type Event record {|
     @display {label: "Event Data"}
-    anydata data;
+    json data;
     @display {label: "Broker Properties"}
     map<json> brokerProperties?;
     @display {label: "User Properties"}


### PR DESCRIPTION
## Purpose
> 
UI form for Send an Event operation doesn't let the user input event data which is of type union or anydata
https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/e04a6c424e6b9ca94f1187ede51df3fdc598a57a/endpoint.bal#L301
https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/e04a6c424e6b9ca94f1187ede51df3fdc598a57a/types.bal#L46
https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/e04a6c424e6b9ca94f1187ede51df3fdc598a57a/endpoint.bal#L303
Union types as parameters are not supported in a user friendly way in Choreo UI.
Need to change the union type of event data parameter in send operation to fix this issue.

Resolves https://github.com/wso2-enterprise/choreo/issues/5492
Resolves https://github.com/wso2-enterprise/choreo/issues/5417

## Goals
> Improve the `Send Event` operation so that the user can provide parameters in a user friendly way through choreo UI.

## Approach
> 
Remove the union type and provide json type for event data to be inline with the Azure documentation
https://docs.microsoft.com/en-us/rest/api/eventhub/send-batch-events
Change userProperties as map<json> instead of map<string>

## Release note
> 
Remove the union type and provide json type for event data
Remove map<anydata> & provide map<json> for brokerProperties optional parameter

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
>
JDK 11
Ballerina SLAlpha5
Ubuntu 20.04
 
## Learning
> 
https://docs.microsoft.com/en-us/rest/api/eventhub/send-batch-events
https://docs.microsoft.com/en-us/rest/api/eventhub/send-event