### PR TITLE
[SL Beta 1] Remove union type for event data

### DIFF
--- a/eventhub/data_mappings.bal
+++ b/eventhub/data_mappings.bal
@@ -25,16 +25,15 @@ import ballerina/xmldata;
 isolated function getBatchEventJson(BatchEvent batchEvent) returns json {
     json[] message = [];
     foreach var item in batchEvent.events {
-        json data = checkpanic item.data.cloneWithType(json);
         json jsonMessage = {
-            Body: data
+            Body: item.data
         };
         if (!(item["userProperties"] is ())) {
-            json userProperties = {UserProperties:checkpanic item["userProperties"].cloneWithType(json)};
+            json userProperties = {UserProperties: checkpanic item["userProperties"].cloneWithType(json)};
             jsonMessage = checkpanic jsonMessage.mergeJson(userProperties);
         }
         if (!(item["brokerProperties"] is ())) {
-            json brokerProperties = {BrokerProperties:checkpanic item["brokerProperties"].cloneWithType(json)};
+            json brokerProperties = {BrokerProperties: checkpanic item["brokerProperties"].cloneWithType(json)};
             jsonMessage = checkpanic jsonMessage.mergeJson(brokerProperties);
         }
         message.push(jsonMessage);

--- a/eventhub/endpoint.bal
+++ b/eventhub/endpoint.bal
@@ -17,8 +17,6 @@
 import ballerina/http;
 import ballerina/lang.'xml as xmllib;
 import ballerina/regex;
-import ballerina/mime;
-import ballerina/io;
 
 # Client for Azure Event Hub connector.
 #
@@ -288,34 +286,33 @@ public client class Client {
     # Send a single event to an Event Hub.
     #
     # + eventHubPath - Event Hub path (Event Hub name)
-    # + data - Event data in string|xml|json|byte[] format
+    # + data - Event data in json format
     # + userProperties - Map of custom properties (Optional)
     # + brokerProperties - Map of broker properties (Optional)
     # + partitionId - Partition ID (Optional)
     # + publisherId - Publisher ID (Optional)
     # + partitionKey - Partition Key (Optional)
-    # + return - Nil on success, else returns an error if remote API is unreachable 
+    # + return - Nil on success, else returns an error if remote API is unreachable
     @display {label: "Send an Event"}
     remote isolated function send(@display {label: "Event Hub Path"} string eventHubPath, 
-                                  @display {label: "Event Data"} 
-                                  string|xml|json|byte[]|mime:Entity[]|stream<byte[], io:Error> data, 
-                                  @display {label: "User Properties"} map<string>? userProperties = (), 
-                                  @display {label: "Broker Properties"} map<anydata>? brokerProperties = (), 
+                                  @display {label: "Event Data"} json data, 
+                                  @display {label: "User Properties"} map<json>? userProperties = (), 
+                                  @display {label: "Broker Properties"} map<json>? brokerProperties = (), 
                                   @display {label: "Partition ID"} int? partitionId = (), 
                                   @display {label: "Publisher ID"} string? publisherId = (), 
                                   @display {label: "Partition Key"} string? partitionKey = ()) 
                                   returns @tainted error? {
         http:Request req = getAuthorizedRequest(self.config);
         check req.setContentType(CONTENT_TYPE_SEND);
-        if (userProperties is map<string>) {
+        if (userProperties is map<json>) {
             foreach var [header, value] in userProperties.entries() {
-            req.addHeader(header, value.toString());
+            req.addHeader(header, value.toJsonString());
         }
         }
-        if (partitionKey is string && brokerProperties is map<anydata>) {
+        if (partitionKey is string && brokerProperties is map<json>) {
             brokerProperties[PARTITION_KEY] = partitionKey;
         } else if (partitionKey is string && brokerProperties is ()) {
-            map<anydata> properties = {};
+            map<json> properties = {};
             properties[PARTITION_KEY] = partitionKey;
             json|error props = properties.cloneWithType(json);
             if (props is error) {
@@ -324,7 +321,7 @@ public client class Client {
                 req.addHeader(BROKER_PROPERTIES, props.toJsonString());
             }
         }
-        if (brokerProperties is map<anydata>) {
+        if (brokerProperties is map<json>) {
             json|error props = brokerProperties.cloneWithType(json);
             if (props is error) {
                 return error Error(BROKER_PROPERTIES_PARSE_ERROR, props);

--- a/eventhub/types.bal
+++ b/eventhub/types.bal
@@ -43,7 +43,7 @@ public type ClientEndpointConfiguration record {|
 @display {label: "Event"}
 public type Event record {|
     @display {label: "Event Data"}
-    anydata data;
+    json data;
     @display {label: "Broker Properties"}
     map<json> brokerProperties?;
     @display {label: "User Properties"}


### PR DESCRIPTION
## Purpose
> 
UI form for Send an Event operation doesn't let the user input event data which is of type union or anydata
https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/e04a6c424e6b9ca94f1187ede51df3fdc598a57a/endpoint.bal#L301
https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/e04a6c424e6b9ca94f1187ede51df3fdc598a57a/types.bal#L46
https://github.com/ballerina-platform/module-ballerinax-azure.eventhub/blob/e04a6c424e6b9ca94f1187ede51df3fdc598a57a/endpoint.bal#L303
Union types as parameters are not supported in a user friendly way in Choreo UI.
Need to change the union type of event data parameter in send operation to fix this issue.

## Goals
> Improve the `Send Event` operation so that the user can provide parameters in a user friendly way through choreo UI.

## Approach
> 
Remove the union type and provide json type for event data to be inline with the Azure documentation
https://docs.microsoft.com/en-us/rest/api/eventhub/send-batch-events
Change userProperties as map<json> instead of map<string>

## Release note
> 
Remove the union type and provide json type for event data
Remove map<anydata> & provide map<json> for brokerProperties optional parameter

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
>
JDK 11
Ballerina Beta1
Ubuntu 20.04
 
## Learning
> 
https://docs.microsoft.com/en-us/rest/api/eventhub/send-batch-events
https://docs.microsoft.com/en-us/rest/api/eventhub/send-event