### PR TITLE
Fix warning messages for unused variables

### DIFF
--- a/eventhub/utils.bal
+++ b/eventhub/utils.bal
@@ -55,7 +55,7 @@ isolated function getAuthorizedRequestHeaderMap(ConnectionConfig config) returns
 # + return - Return SAS token
 isolated function getSASToken(ConnectionConfig config) returns string {
     time:Utc time = time:utcNow();
-    [int, decimal][epochSeconds, lastSecondFraction] = time;
+    [int, decimal][epochSeconds, _] = time;
     int week = 60 * 60 * 24 * 7;
     int expiry = epochSeconds + week;
     string stringToSign = checkpanic url:encode(config.resourceUri, UTF8_URL_ENCODING) + "\n" + 


### PR DESCRIPTION
# Description

Fix the following warning message in daily builds
```
WARNING [utils.bal:(58:34,58:52)] unused variable 'lastSecondFraction'
```

Fixes # ([issue](https://github.com/ballerina-platform/ballerina-extended-library/issues/193))

One line release note: 
- Fix warning messages for unused variables

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: SLBeta5
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
